### PR TITLE
Removed -browser()-

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: approxmapR
 Type: Package
 Title: ApproxMAP (APPROXimate Multiple Alignment Pattern)
-Version: 1.2
+Version: 1.3
 Author: Gurudev Ilngovan, Corey Bryant, and Hye Chung Kum.
 Maintainer: The package maintainer <yourself@somewhere.net>
 Description: ApproxMAP (APPROXimate Multiple Alignment Pattern). Is an efficient and effective mining algorithm which finds maximal approximate sequential patterns.

--- a/R/reports.R
+++ b/R/reports.R
@@ -308,7 +308,7 @@ print_alignments <- function(df) {
 
 align_date_to_seq <- function(current_id, seq){
 
-  browser()
+  #browser()
 
   id_elements <- unlist(seq)
 


### PR DESCRIPTION
While coding v1.2, developer forgot to remove the browser() functions which were used during development. This small patch removes those.